### PR TITLE
chore: Change url of docker image in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ To initialize the database, run the server once with `--create_db`.
 ## Docker
 
 The provided dockerfile makes it easy to use the software as a docker
-container. The latest state of the master branch can be found as a
-[Automated build on the Docker hub](https://hub.docker.com/r/janlo/wallabag-kindle-consumer).
+container. The latest state of the main branch can be found as a
+[Automated build on ghcr.io](https://github.com/natilou/wallabag-kindle-consumer/pkgs/container/wallabag-kindle-consumer).
 
 You can easily configure the container via the environment variables from
 above. Just make sure, that the database is in a volume if you use sqlite.


### PR DESCRIPTION
Currently the image is automated build on ghcr.io