### PR TITLE
chore: Upgrade to Python 3.11

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.9.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py311-plus]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
-FROM python:3.7-alpine
-# TODO: update python version
-MAINTAINER Jan Losinski <losinski@wh2.tu-dresden.de>
-# TODO: MAINTAINER has been deprecated
-# https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
+FROM python:3.11-alpine
 
-ADD requirements.txt /tmp
+COPY requirements.txt /tmp
 RUN apk add -U --virtual .bdep \
     build-base \
     gcc \
@@ -12,11 +8,10 @@ RUN apk add -U --virtual .bdep \
     pip install -r /tmp/requirements.txt && \
     apk del .bdep
 
-ADD . /app
-VOLUME /data
-
 WORKDIR /app
+COPY . .
 
+VOLUME /data
 EXPOSE 8080
 
 CMD ./service.py --refresher --consumer --interface --env

--- a/wallabag_kindle_consumer/sender.py
+++ b/wallabag_kindle_consumer/sender.py
@@ -21,7 +21,7 @@ class Sender:
 
     def _send_mail(self, title, article, format, email, data):
         msg = MIMEMultipart()
-        msg['Subject'] = "Send article '{}'".format(title)
+        msg['Subject'] = f"Send article '{title}'"
         msg['From'] = self.from_addr
         msg['To'] = email
         msg['Date'] = formatdate(localtime=True)
@@ -33,7 +33,7 @@ class Sender:
         mobi = MIMEApplication(data)
         encode_base64(mobi)
         mobi.add_header('Content-Disposition', 'attachment',
-                        filename='{title}.{format}'.format(title=title, format=format))
+                        filename=f'{title}.{format}')
 
         msg.attach(mobi)
 
@@ -43,10 +43,7 @@ class Sender:
             smtp.login(self.user, self.passwd)
         smtp.sendmail(self.from_addr, [email], msg.as_string())
         smtp.quit()
-        logger.info("Mail with article {article} in format {format} with title '{title}' sent to {email}".format(article=article,
-                                                                                            title=title,
-                                                                                            format=format,
-                                                                                            email=email))
+        logger.info(f"Mail with article {article} in format {format} with title '{title}' sent to {email}")
 
     async def send_mail(self, job, data):
         return self.loop.run_in_executor(None, self._send_mail, job.title, job.article, job.format,

--- a/wallabag_kindle_consumer/wallabag.py
+++ b/wallabag_kindle_consumer/wallabag.py
@@ -26,10 +26,10 @@ Tag = namedtuple('Tag', ['tag', 'format'])
 
 
 def make_tags(tag):
-    return (Tag(tag='{tag}'.format(tag=tag), format='epub'),
-            Tag(tag='{tag}-epub'.format(tag=tag), format='epub'),
-            Tag(tag='{tag}-mobi'.format(tag=tag), format='mobi'),
-            Tag(tag='{tag}-pdf'.format(tag=tag), format='pdf'))
+    return (Tag(tag=f'{tag}', format='epub'),
+            Tag(tag=f'{tag}-epub', format='epub'),
+            Tag(tag=f'{tag}-mobi', format='mobi'),
+            Tag(tag=f'{tag}-pdf', format='pdf'))
 
 
 class Wallabag:
@@ -89,7 +89,7 @@ class Wallabag:
 
     async def fetch_entries(self, user):
         if user.auth_token is None:
-            logger.warn("No auth token for {}".format(user.name))
+            logger.warn(f"No auth token for {user.name}")
             return
         async with aiohttp.ClientSession() as session:
             for tag in self.tags:
@@ -109,8 +109,8 @@ class Wallabag:
 
     async def remove_tag(self, user, article):
         params = self._api_params(user)
-        url = self._url('/api/entries/{entry}/tags/{tag}.json'.format(entry=article.id,
-                                                                      tag=article.tag_id()))
+        tag = article.tag_id()
+        url = self._url(f'/api/entries/{article.id}/tags/{tag}.json')
 
         async with aiohttp.ClientSession() as session:
             async with session.delete(url, params=params) as resp:
@@ -123,7 +123,7 @@ class Wallabag:
 
     async def export_article(self, user, article_id, format):
         params = self._api_params(user)
-        url = self._url("/api/entries/{entry}/export.{format}".format(entry=article_id, format=format))
+        url = self._url(f"/api/entries/{article_id}/export.{format}")
 
         async with aiohttp.ClientSession() as session:
             async with session.get(url, params=params) as resp:


### PR DESCRIPTION
This change also includes the configuration of a pre-commit hook for [`pyupgrade`](https://github.com/asottile/pyupgrade), using the `--py311-plus` flag to rewrite any code that can be updated to newer conventions.