### PR TITLE
chore: Modified semantic-pr workflow

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,25 +1,21 @@
-name: "Check Semantic Commit"
+name: "Check Semantic PR"
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited
       - synchronize
 
 permissions:
-  contents: read
+  pull-requests: read
 
 jobs:
   main:
-    permissions:
-      pull-requests: read  # for amannn/action-semantic-pull-request to analyze PRs
-      statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
-    name: Validate PR Title
+    name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - name: semantic-pull-request
-        uses: amannn/action-semantic-pull-request@01d5fd8a8ebb9aafe902c40c53f0f4744f7381eb # tag: v5
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
- The previous workflow only worked if the branch is based in the repository itself, it didn't work in a fork-based workflow. This error was fixed using `pull_request_target` instead of `pull_request`. [Documentation](https://github.com/amannn/action-semantic-pull-request)