### PR TITLE
chore!: refactor of Config class

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ COPY . .
 VOLUME /data
 EXPOSE 8080
 
-CMD ./service.py --refresher --consumer --interface --env
+CMD ./service.py --refresher --consumer --interface

--- a/Pipfile
+++ b/Pipfile
@@ -3,6 +3,7 @@ aiohttp = "~= 3.8"
 aiohttp-jinja2 = "~= 1.5"
 email-validator = "~= 2.0"
 Jinja2 = "~= 3.1"
+python-decouple = "~= 3.8"
 SQLAlchemy = "~= 2.0"
 uvloop = "~= 0.17"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f8b9d452eefd24e76e8d10324b8d124f956f20e11dbc064c82ec0ed3ff6441eb"
+            "sha256": "d7d5f7a20e6fe744aa13a4e13d83cc3f3759109da2e547e288487793062fcbdf"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -127,11 +127,11 @@
         },
         "async-timeout": {
             "hashes": [
-                "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15",
-                "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"
+                "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f",
+                "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==4.0.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==4.0.3"
         },
         "attrs": {
             "hashes": [
@@ -224,11 +224,11 @@
         },
         "dnspython": {
             "hashes": [
-                "sha256:5b7488477388b8c0b70a8ce93b227c5603bc7b77f1565afe8e729c36c51447d7",
-                "sha256:c33971c79af5be968bb897e95c2448e11a645ee84d93b265ce0b7aabe5dfdca8"
+                "sha256:57c6fbaaeaaf39c891292012060beb141791735dbb4004798328fc2c467402d8",
+                "sha256:8dcfae8c7460a2f84b4072e26f1c9f4101ca20c071649cb7c34e8b6a93d58984"
             ],
             "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==2.4.1"
+            "version": "==2.4.2"
         },
         "email-validator": {
             "hashes": [
@@ -387,46 +387,6 @@
             "index": "pypi",
             "version": "==3.1.2"
         },
-        "logbook": {
-            "hashes": [
-                "sha256:156abef6eaf1237b40fcfabf2c92040e95c06b78000540714bf5edb52014c830",
-                "sha256:188e30545b1178c4e72cc095abe6209ad33d52d2f49bfe6a3311f3692b01d996",
-                "sha256:19ca62baa4440d1d9f58fce309ed01d373bfea017e1128f9edbc198cb8ded54b",
-                "sha256:1a62e38a0532770b0c64e29e481df80054a47bffddd247381f2b3a16e136024f",
-                "sha256:27886786d856e02168c117c783d49a628b97eed737c9ece04abd11ff8e53ef28",
-                "sha256:281cf72abc25a776cc2c131cc90282830c447e72d76796974cc0e317812b133d",
-                "sha256:2b9a351b33c179d733b83ce9c4b66dea22930b3f6262b116ac62168859a70ee4",
-                "sha256:33bfc3b3a318778eda21291ab752d8a90f10c9488767b7c82d4f7633133a1490",
-                "sha256:365bf89b01822d895fc8471510341b742bb32a7e431cd81d0d16b91ccf3b889f",
-                "sha256:43409f5cead00f783e206046dbbc2c473c1fa8582fe11ad1c4e2cc3241b9480e",
-                "sha256:5057b1ee02832fea1f25a986c20768365121737f457ede2900e1e245faa9165e",
-                "sha256:608e03f4dccff07cc3f7ab470b71a7baa7219b7369a1d963191b5ee2782d26e4",
-                "sha256:6204d0828334ac00525b473bbbca5bdc5c22fa3592ed216eb77842b44777dd91",
-                "sha256:68dcf7784de99d2e03e15997ba1b573a76121f29b6117116e9a8c2de804a4e0d",
-                "sha256:78f69cb95b7cd11197cd3ac2c6f402f8cfd3e8e7c657bc8c01bb2e00779804b2",
-                "sha256:7cf2440329504c7b5ff0c19d2a4f1a9504a89154ba44c8251b102ebe8d66b0e9",
-                "sha256:82e3fa2a9d4598ab5bb4a18f54acf4ed1c2e7a542b6f8c7b08fbc652279b8f52",
-                "sha256:91ea8718b84c570bf44224c5ad82c6ad9e221b70db365d44f8e64937416247fd",
-                "sha256:924c12e35379d270a8311e35ae0e649cb8eb2e55ab0e08055bbcc86c468cc176",
-                "sha256:9b726d51f0a531045210c564124ddee2580f32e50928da5458263ab77e6e8268",
-                "sha256:9eba2d642c55aa01a9481081142abe437db894e9ece0d34c3ec90c6df2e6fec0",
-                "sha256:a50a0cb1fdd0f58c8cc0ac252bb1683e63caa49872b77c3812cde5d3db73d97f",
-                "sha256:aa5207ad67358564c3a4c204d23a87eea57d46b42369d32df35544effc6b61c6",
-                "sha256:b6ff13ecb9c5f11bc2a0e0bcdf3c5f9fdb555592b6451fb329b89286e749294a",
-                "sha256:b71c5afd7d0acc30244494cb8bff820f4ac4a314dbb00e19f937425d90547175",
-                "sha256:b941633da43034aeb0bedbaef2a2808a23356a58dc7f2c781ee56de3d1b612d4",
-                "sha256:c26ecb7a2a8deb1a9edace60c2f884e5c9726bcb6f3b30643a6d2d1ff21b9d63",
-                "sha256:d1eb3bc33ae77e0a97c24f042f59b6ec640ad285e12f3c2cb79a9f86756d2425",
-                "sha256:d4b2f88c8a68f332620eadaae05a905963cd61f5ec3c9b54c6eb6420601463da",
-                "sha256:e1e18eb6a34344cf9bffa56110c1906d661ff9778c82f2a8d73d5423e2f967b3",
-                "sha256:e342eeda6c5feda5c371c05d84875bb71c21c9a0a4eaa10ed5c8902e950e608d",
-                "sha256:e630264b74af3c07fa5e824b2b5bef8be5df5f97271d04e613c8042268403d26",
-                "sha256:ef062b6b0b4276a9c4afb9c7ab54d54b1b453e47f74f5c7a24e12c5f1c3767bf",
-                "sha256:f999d538306aab8123c04c59c009fc52c7a98753ea69aad9bb44bebd5223457e"
-            ],
-            "index": "pypi",
-            "version": "==1.6.0"
-        },
         "markupsafe": {
             "hashes": [
                 "sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e",
@@ -562,6 +522,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==6.0.4"
+        },
+        "python-decouple": {
+            "hashes": [
+                "sha256:ba6e2657d4f376ecc46f77a3a615e058d93ba5e465c01bbe57289bfb7cce680f",
+                "sha256:d0d45340815b25f4de59c974b855bb38d03151d81b037d9e3f463b0c9f8cbd66"
+            ],
+            "index": "pypi",
+            "version": "==3.8"
         },
         "sqlalchemy": {
             "hashes": [
@@ -750,14 +718,6 @@
             ],
             "version": "==0.2.0"
         },
-        "cfgv": {
-            "hashes": [
-                "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426",
-                "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"
-            ],
-            "markers": "python_full_version >= '3.6.1'",
-            "version": "==3.3.1"
-        },
         "decorator": {
             "hashes": [
                 "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330",
@@ -766,35 +726,12 @@
             "markers": "python_version >= '3.11'",
             "version": "==5.1.1"
         },
-        "distlib": {
-            "hashes": [
-                "sha256:2e24928bc811348f0feb63014e97aaae3037f2cf48712d51ae61df7fd6075057",
-                "sha256:9dafe54b34a028eafd95039d5e5d4851a13734540f1331060d31c9916e7147a8"
-            ],
-            "version": "==0.3.7"
-        },
         "executing": {
             "hashes": [
                 "sha256:0314a69e37426e3608aada02473b4161d4caf5a4b244d1d0c48072b8fee7bacc",
                 "sha256:19da64c18d2d851112f09c287f8d3dbbdf725ab0e569077efb6cdcbd3497c107"
             ],
             "version": "==1.2.0"
-        },
-        "filelock": {
-            "hashes": [
-                "sha256:002740518d8aa59a26b0c76e10fb8c6e15eae825d34b6fdf670333fd7b938d81",
-                "sha256:cbb791cdea2a72f23da6ac5b5269ab0a0d161e9ef0100e653b69049a7706d1ec"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.12.2"
-        },
-        "identify": {
-            "hashes": [
-                "sha256:7243800bce2f58404ed41b7c002e53d4d22bcf3ae1b7900c2d7aefd95394bf7f",
-                "sha256:c22a8ead0d4ca11f1edd6c9418c3220669b3b7533ada0a0ffa6cc0ef85cf9b54"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.5.26"
         },
         "ipdb": {
             "hashes": [
@@ -828,14 +765,6 @@
             "markers": "python_version >= '3.5'",
             "version": "==0.1.6"
         },
-        "nodeenv": {
-            "hashes": [
-                "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2",
-                "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
-            "version": "==1.8.0"
-        },
         "parso": {
             "hashes": [
                 "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0",
@@ -858,22 +787,6 @@
                 "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
             ],
             "version": "==0.7.5"
-        },
-        "platformdirs": {
-            "hashes": [
-                "sha256:b45696dab2d7cc691a3226759c0d3b00c47c8b6e293d96f6436f733303f77f6d",
-                "sha256:d7c24979f292f916dc9cbf8648319032f551ea8c49a4c9bf2fb556a02070ec1d"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.10.0"
-        },
-        "pre-commit": {
-            "hashes": [
-                "sha256:10badb65d6a38caff29703362271d7dca483d01da88f9d7e05d0b97171c136cb",
-                "sha256:a2256f489cd913d575c145132ae196fe335da32d91a8294b7afe6622335dd023"
-            ],
-            "index": "pypi",
-            "version": "==3.3.3"
         },
         "prompt-toolkit": {
             "hashes": [
@@ -899,65 +812,11 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c",
-                "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"
+                "sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692",
+                "sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.15.1"
-        },
-        "pyyaml": {
-            "hashes": [
-                "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc",
-                "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741",
-                "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206",
-                "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27",
-                "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595",
-                "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62",
-                "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98",
-                "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696",
-                "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d",
-                "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867",
-                "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47",
-                "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486",
-                "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6",
-                "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3",
-                "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007",
-                "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938",
-                "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c",
-                "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735",
-                "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d",
-                "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba",
-                "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
-                "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5",
-                "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd",
-                "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3",
-                "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0",
-                "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515",
-                "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c",
-                "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c",
-                "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924",
-                "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34",
-                "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43",
-                "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859",
-                "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673",
-                "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a",
-                "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab",
-                "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa",
-                "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c",
-                "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585",
-                "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d",
-                "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==6.0.1"
-        },
-        "setuptools": {
-            "hashes": [
-                "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f",
-                "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==68.0.0"
+            "version": "==2.16.1"
         },
         "six": {
             "hashes": [
@@ -981,14 +840,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==5.9.0"
-        },
-        "virtualenv": {
-            "hashes": [
-                "sha256:43a3052be36080548bdee0b42919c88072037d50d56c28bd3f853cbe92b953ff",
-                "sha256:fd8a78f46f6b99a67b7ec5cf73f92357891a7b3a40fd97637c27f854aae3b9e0"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==20.24.2"
         },
         "wcwidth": {
             "hashes": [

--- a/config.example.ini
+++ b/config.example.ini
@@ -1,11 +1,11 @@
-[DEFAULT]
-db_uri = sqlite:///database.db
-wallabag_host = https://wallabag.myserver.org
-client_id = 1_3o53gl30vhgk0c8ks4cocww08o84448osgo40wgw4gwkoo8skc
-client_secret = 636ocbqo978ckw0gsw4gcwwocg8044sco0w8w84cws48ggogs4
-domain = https://consumer.myserver.org
-smtp_from = wallabag@myserver.org
-smtp_host = myserver.org
-smtp_port = 587
-smtp_user = mail_user
-smtp_passwd = mail_pass
+[settings]
+DB_URI = sqlite:///database.db
+WALLABAG_HOST = https://wallabag.myserver.org
+CLIENT_ID = 1_3o53gl30vhgk0c8ks4cocww08o84448osgo40wgw4gwkoo8skc
+CLIENT_SECRET = 636ocbqo978ckw0gsw4gcwwocg8044sco0w8w84cws48ggogs4
+DOMAIN = https://consumer.myserver.org
+SMTP_FROM = wallabag@myserver.org
+SMTP_HOST = myserver.org
+SMTP_PORT = 587
+SMTP_USER = mail_user
+SMTP_PASSWD = mail_pass

--- a/service.py
+++ b/service.py
@@ -8,7 +8,7 @@ import signal
 import uvloop
 
 from wallabag_kindle_consumer import models
-from wallabag_kindle_consumer.config import Config
+from wallabag_kindle_consumer.config import Configuration
 from wallabag_kindle_consumer.consumer import Consumer
 from wallabag_kindle_consumer.interface import App
 from wallabag_kindle_consumer.refresher import Refresher
@@ -18,8 +18,7 @@ from wallabag_kindle_consumer.wallabag import Wallabag
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Wallabag-Kindle-Consumer")
-    parser.add_argument("--cfg", help="config file", required=False)
-    parser.add_argument("--env", help="Read config from env", action="store_true")
+    parser.add_argument("--cfg", help="Path to config file", required=False)
     parser.add_argument("--refresher", help="Start token refresher", action="store_true")
     parser.add_argument("--interface", help="Start web interface", action="store_true")
     parser.add_argument("--consumer", help="Start article consumer", action="store_true")
@@ -40,17 +39,7 @@ if __name__ == "__main__":
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
 
-    config = Config.from_file("config.ini")
-
-    if "cfg" in args and args.cfg is not None:
-        new = Config.from_file(args.cfg)
-        if new is not None:
-            config = new
-
-    if "env" in args and args.env:
-        new = Config.from_env()
-        if new is not None:
-            config = new
+    config = Configuration.build(config_file_path=args.cfg)
 
     if args.create_db:
         models.create_db(config)


### PR DESCRIPTION
- using [python-decouple](https://github.com/HBNetwork/python-decouple) to build the configuration from environment variables or config files (.env or .ini, for example)
- deleting "--env" argument, because by default the python-decouple library search environment variables.
- now, after the "--cfg" argument we can pass the path to the config file
- and this library search for the variables in upper case, so the config.ini must have the variables in upper case.