### PR TITLE
chore: optional email encryption

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a372ce83de24bb3550239ce2886b73e47e046b683019acd568cf960454f860cf"
+            "sha256": "d7d5f7a20e6fe744aa13a4e13d83cc3f3759109da2e547e288487793062fcbdf"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ Since the original repository has not been maintained, I am now actively maintai
 
 This is a service that polls a [Wallabag](https://wallabag.org/en)
 instance for articles with a certain tag (`kindle`, `kindle-mobi` or
-`kindle-pdf`). If it finds an article tagged with one of thse tags, it
+`kindle-pdf`). If it finds an article tagged with one of those tags, it
 exports the article in the requested format and sends it via email to a
-configured kindle adress.
+configured kindle address.
 
 The software consists of three parts:
 
-* **consumer:** This is the part that consumes the tags from wallabag
+* **consumer:** This is the part that consumes the tags from Wallabag
   and pushes them to the kindle addresses.
-* **refresher:** As wallabag gives no permanent api tokens we need to
+* **refresher:** As Wallabag gives no permanent api tokens we need to
   refresh them regularly. This part asks for a new token every time the
   old one is due to expire. With this method we don't need to save the
   users password. If we miss a refresh cycle (for example because the
@@ -23,7 +23,7 @@ The software consists of three parts:
 * **interface:** This provides a basic web interface to register new
   users, refresh logins or delete users.
 
-All parts can run in one process or you can use seperate processes for
+All parts can run in one process or you can use separate processes for
 each part. All they share is the configuration and the database.
 
 ## Configuration
@@ -33,35 +33,34 @@ or via environment variables. The later is used for running the service
 via docker. All config option have ro be below a section called `DEFAULT`.
 You can just copy and modify the example config.
 
-The following tabe describes all options:
+The following table describes all options:
 
-| file-option       | env-var            | type     | default    | description |
-|-------------------|--------------------|----------|------------|----------|
-|`wallabag_host`    | `WALLABAG_HOST`    | required |            | The http url of the wallabag host. |
-|`db_uri`           | `DB_URI`           | required |            | The dbapi url for the database. |
-|`client_id`        | `CLIENT_ID`        | required |            | The Wallabag client id. Read [here](https://doc.wallabag.org/en/developer/api/oauth.html) how to get it.  |
-|`client_secret`    | `CLIENT_SECRET`    | required |            | The Wallabag client secret. Read above. |
-|`domain`           | `DOMAIN`           | required |            | the domain the interface for the service is accessible on. |
-|`smtp_from`        | `SMTP_FROM`        | required |            | The from-address to use. |
-|`smtp_host`        | `SMTP_HOST`        | required |            | The SMTP hostname or ip. |
-|`smtp_port`        | `SMTP_PORT`        | required |            | The Port of the SMTP server. |
-|`smtp_user`        | `SMTP_USER`        | required |            | The user for SMTP auth. |
-|`smtp_passwd`      | `SMTP_PASSWD`      | required |            | The password for SMTP auth. |
-|`tag`              | `TAG`              | optional | `kindle`   | The tag to consume. |
-|`refresh_grace`    | `REFRESH_GRACE`    | optional | `120`      | The amount of seconds the token is refreshed before expiring. |
-|`consume_interval` | `CONSUME_INTERVAL` | optional | `30`       | The time in seconds between two consume cycles. |
-|`interface_host`   | `INTERFACE_HOST`   | optional | `120.0.0.1`| The IP the user interface should bind to.  |
-|`interface_port`   | `INTERFACE_PORT`   | optional | `8080`     | The port the user interface should bind. |
+|file-option  / env-var | type     | default    | description |
+------------------------|----------|------------|----------|
+|`WALLABAG_HOST`        | required |            | The http url of the Wallabag host. |
+|`DB_URI`               | required |            | The dbapi url for the database. |
+|`CLIENT_ID`            | required |            | The Wallabag client id. Read [here](https://doc.wallabag.org/en/developer/api/oauth.html) how to get it.    |
+|`CLIENT_SECRET`        | required |            | The Wallabag client secret. Read above. |
+|`DOMAIN`               | required |            | the domain the interface for the service is accessible on. |
+|`SMTP_FROM`            | required |            | The from-address to use. |
+|`SMTP_HOST`            | required |            | The SMTP hostname or ip. |
+|`SMTP_PORT`            | required |            | The Port of the SMTP server. |
+|`SMTP_USER`            | required |            | The user for SMTP auth. |
+|`SMTP_PASSWD`          | required |            | The password for SMTP auth. |
+|`SMTP_TLS   `          | optional |  True      | Enable email encryption. |
+|`TAG`                  | optional | `kindle`   | The tag to consume. |
+|`REFRESH_GRACE`        | optional | `120`      | The amount of seconds the token is refreshed before expiring. |
+|`CONSUME_INTERVAL`     | optional | `30`       | The time in seconds between two consume cycles. |
+|`INTERFACE_HOST`       | optional | `120.0.0.1`| The IP the user interface should bind to.  |
+|`INTERFACE_PORT`       | optional | `8080`     | The port the user interface should bind. |
 
-The config file is read either from the current working dicectory where it
-would be called `config.ini` or from a path hiven to the commandline option
-`--cfg`. To use configuration via environment use `--env`.
+The configuration is read by default from the environment. But it could be read either from a `.ini` or `.env` file or from a path given to the commandline option `--cfg`.
 
 
 ## Running
 
-Every component must be enabled via a commandline switch. To runn all three
-in one prcess use all three:
+Every component must be enabled via a commandline switch. To run all three
+in one process use all three:
 ```
 $ ./service.py --refresher --consumer --interface
 ```
@@ -71,7 +70,7 @@ For more information about commandline options use `--help`.
 
 ## Database
 
-The servie uses a database. The easiest option is to use sqlite. To save
+The service uses a database. The easiest option is to use sqlite. To save
 all data in a file called database.db in the current working directory set
 `sqlite:///database.db` in the config option `db_uri` or the env variable
 `DB_URI`.
@@ -82,7 +81,7 @@ To initialize the database, run the server once with `--create_db`.
 ## Docker
 
 The provided dockerfile makes it easy to use the software as a docker
-container. The most recent version from the main branch is available through an
+container. The most recent version from the main branch is available through a
 [automated build on ghcr.io](https://github.com/natilou/wallabag-kindle-consumer/pkgs/container/wallabag-kindle-consumer).
 
 You can easily configure the container via the environment variables from
@@ -91,11 +90,11 @@ above. Just make sure, that the database is in a volume if you use sqlite.
 
 ## Usage
 
-As soon as you've set it all up you can reister your wallabag user in the
+As soon as you've set it all up you can register your Wallabag user in the
 Web-UI. The service does not store any login information other than the
-user name and the API token for wallabag. All actions that need a valid
+user name and the API token for Wallabag. All actions that need a valid
 user like register/login/delete a user are authenticated directly against
-the wallabag server.
+the Wallabag server.
 
 ## License
 

--- a/service.py
+++ b/service.py
@@ -57,7 +57,15 @@ if __name__ == "__main__":
     loop.add_signal_handler(signal.SIGINT, _stop)
 
     wallabag = Wallabag(config)
-    sender = Sender(loop, config.smtp_from, config.smtp_host, config.smtp_port, config.smtp_user, config.smtp_passwd)
+    sender = Sender(
+        loop=loop,
+        from_addr=config.smtp_from,
+        smtp_server=config.smtp_host,
+        smtp_port=config.smtp_port,
+        smtp_user=config.smtp_user,
+        smtp_passwd=config.smtp_passwd,
+        smtp_tls=config.smtp_tls,
+    )
 
     if args.refresher:
         logging.info("Create Refresher")

--- a/wallabag_kindle_consumer/config.py
+++ b/wallabag_kindle_consumer/config.py
@@ -17,6 +17,7 @@ class Configuration:
     smtp_port: int
     smtp_user: str
     smtp_passwd: str
+    smtp_tls: bool
     tag: str
     refresh_grace: int
     consume_interval: int
@@ -42,6 +43,7 @@ class Configuration:
                 smtp_port=cfg("SMTP_PORT", cast=int),
                 smtp_user=cfg("SMTP_USER"),
                 smtp_passwd=cfg("SMTP_PASSWD"),
+                smtp_tls=cfg("SMTP_TLS", default=True, cast=bool),
                 tag=cfg("TAG", default="kindle"),
                 refresh_grace=cfg("REFRESH_GRACE", default=120, cast=int),
                 consume_interval=cfg("CONSUME_INTERVAL", default=30, cast=int),

--- a/wallabag_kindle_consumer/sender.py
+++ b/wallabag_kindle_consumer/sender.py
@@ -9,13 +9,14 @@ from wallabag_kindle_consumer.logger import logger
 
 
 class Sender:
-    def __init__(self, loop, from_addr, smtp_server, smtp_port, smtp_user=None, smtp_passwd=None):
+    def __init__(self, loop, from_addr, smtp_server, smtp_port, smtp_user=None, smtp_passwd=None, smtp_tls=True):
         self.from_addr = from_addr
         self.loop = loop
         self.host = smtp_server
         self.port = smtp_port
         self.user = smtp_user
         self.passwd = smtp_passwd
+        self.encryption_enabled = smtp_tls
 
     def _send_mail(self, title, article, format, email, data):
         msg = MIMEMultipart()
@@ -35,7 +36,8 @@ class Sender:
         msg.attach(mobi)
 
         smtp = smtplib.SMTP(host=self.host, port=self.port)
-        smtp.starttls()
+        if self.encryption_enabled:
+            smtp.starttls()
         if self.user:
             smtp.login(self.user, self.passwd)
         try:
@@ -69,7 +71,8 @@ class Sender:
         msg.attach(txt)
 
         smtp = smtplib.SMTP(host=self.host, port=self.port)
-        smtp.starttls()
+        if self.encryption_enabled:
+            smtp.starttls()
         if self.user:
             smtp.login(self.user, self.passwd)
         try:


### PR DESCRIPTION
- adding an optional configuration to disable the email encryption (`SMTP_TLS`). By default, the encryption is enable, so the variable in the `Configuration` is a boolean, which value is `True` by default.
- updating `README` file with the new configuration.

Fixes #13 