### PR TITLE
chore: removing kindle hardcoding from Wallabag.tag 

### DIFF
--- a/wallabag_kindle_consumer/wallabag.py
+++ b/wallabag_kindle_consumer/wallabag.py
@@ -39,7 +39,7 @@ def make_tags(tag: str) -> tuple[Tag, ...]:
 class Wallabag:
     def __init__(self, config: Configuration):
         self.config = config
-        self.tag = "kindle"
+        self.tag = config.tag
         self.tags = make_tags(self.tag)
 
     async def get_token(self, user: User, passwd: str) -> bool:


### PR DESCRIPTION
removing `kindle` hard coding from `Wallabag.tag` and using the` Config.tag`, which has `kindle` as default value