### PR TITLE
feat: Implemented configuration to set a default format for the TAG option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The following table describes all options:
 |`SMTP_PASSWD`          | required |            | The password for SMTP auth. |
 |`SMTP_TLS`             | optional |  True      | Enable email encryption. Set to False or 0 to disable it.|
 |`TAG`                  | optional | `kindle`   | The tag to consume. |
+|`DEFAULT_FORMAT`       | optional | `epub  `   | The default format for the TAG option. Available formats from [Wallabag API](https://app.wallabag.it/api/doc/): xml, json, txt, csv, pdf, epub, mobi|
 |`REFRESH_GRACE`        | optional | `120`      | The amount of seconds the token is refreshed before expiring. |
 |`CONSUME_INTERVAL`     | optional | `30`       | The time in seconds between two consume cycles. |
 |`INTERFACE_HOST`       | optional | `120.0.0.1`| The IP the user interface should bind to.  |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - CLIENT_SECRET=2049390EXAMPLECLIENTSECR3Tkslgsa
       - SMTP_TLS=0
       - TAG=kindle
+      - DEFAULT_FORMAT=pdf
       - WALLABAG_HOST=http://mock-server:80
     volumes:
       - ./data:/data

--- a/wallabag_kindle_consumer/config.py
+++ b/wallabag_kindle_consumer/config.py
@@ -21,6 +21,7 @@ class Configuration:
     smtp_passwd: str
     smtp_tls: bool
     tag: str
+    default_format: str
     refresh_grace: int
     consume_interval: int
     interface_host: str
@@ -47,6 +48,7 @@ class Configuration:
                 smtp_passwd=cfg("SMTP_PASSWD"),
                 smtp_tls=cfg("SMTP_TLS", default=True, cast=bool),
                 tag=cfg("TAG", default="kindle"),
+                default_format=cfg("DEFAULT_FORMAT", default="epub"),
                 refresh_grace=cfg("REFRESH_GRACE", default=120, cast=int),
                 consume_interval=cfg("CONSUME_INTERVAL", default=30, cast=int),
                 interface_host=cfg("INTERFACE_HOST", default="127.0.0.1"),

--- a/wallabag_kindle_consumer/interface.py
+++ b/wallabag_kindle_consumer/interface.py
@@ -94,7 +94,7 @@ class ViewBase(web.View):
                 "data": self._data,
                 "messages": self._messages,
                 "wallabag_host": self._cfg.wallabag_host,
-                "tags": [t.tag for t in wallabag.make_tags(self._cfg.tag)],
+                "tags": [t.tag for t in wallabag.make_tags(tag=self._cfg.tag, default_format=self._cfg.default_format)],
             }
         )
         return vars

--- a/wallabag_kindle_consumer/wallabag.py
+++ b/wallabag_kindle_consumer/wallabag.py
@@ -27,9 +27,9 @@ class Article:
 Tag = namedtuple("Tag", ["tag", "format"])
 
 
-def make_tags(tag: str) -> tuple[Tag, ...]:
+def make_tags(tag: str, default_format: str) -> tuple[Tag, ...]:
     return (
-        Tag(tag=f"{tag}", format="epub"),
+        Tag(tag=f"{tag}", format=default_format),
         Tag(tag=f"{tag}-epub", format="epub"),
         Tag(tag=f"{tag}-mobi", format="mobi"),
         Tag(tag=f"{tag}-pdf", format="pdf"),
@@ -40,7 +40,7 @@ class Wallabag:
     def __init__(self, config: Configuration):
         self.config = config
         self.tag = config.tag
-        self.tags = make_tags(self.tag)
+        self.tags = make_tags(tag=self.tag, default_format=config.default_format)
 
     async def get_token(self, user: User, passwd: str) -> bool:
         params = {


### PR DESCRIPTION
   - If the default format is not specified, the default value is "epub".
   - Fixes #17